### PR TITLE
i18n: survive a new-language bootstrap; per-script length floor

### DIFF
--- a/tools/check_repo.py
+++ b/tools/check_repo.py
@@ -14,7 +14,10 @@ produced or can produce, and that nothing else in CI would notice:
             The figure renderers call str.format() on these values, so a
             renamed placeholder is a crash, not a typo.
   mirror  — every canonical doc has a twin in every language, and every
-            markdown file carries a language bar under its H1.
+            markdown file carries a language bar under its H1. A twin the
+            sync has never recorded in translations/.sync-state.json is a
+            bootstrap still in flight (a freshly declared language), not
+            breakage — the nightly sync drains it.
 
 Usage: python tools/check_repo.py [--only links|labels|mirror]
 Exit code 1 if anything failed.
@@ -66,12 +69,32 @@ def canonical_docs() -> list[str]:
     return sorted(docs)
 
 
+def langbar_lineno(lines: list[str]) -> int | None:
+    """1-based line number of the language bar under the H1, if present."""
+    for i, l in enumerate(lines):
+        if l.startswith("# "):
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j < len(lines) and lines[j].startswith("> ") and "·" in lines[j]:
+                return j + 1
+            return None
+    return None
+
+
 def check_links() -> list[str]:
     bad = []
     for md in markdown_files():
         rel_md = md.relative_to(ROOT).as_posix()
         text = md.read_text(encoding="utf-8")
-        for i, line in enumerate(text.splitlines(), 1):
+        lines = text.splitlines()
+        # the bar is machine-generated every sync and may legitimately point
+        # at a mirror the bootstrap has not written yet; mirror completeness
+        # (with its pending-bootstrap tolerance) governs those targets
+        bar = langbar_lineno(lines)
+        for i, line in enumerate(lines, 1):
+            if i == bar:
+                continue
             for m in LINK_RE.finditer(line):
                 dest = split_dest(m.group(1) if m.group(1) is not None else m.group(2))
                 if not dest or dest.startswith(("http", "mailto:", "/")):
@@ -115,13 +138,26 @@ def check_labels() -> list[str]:
     return bad
 
 
+def synced_pairs() -> set[str]:
+    """'<canon>|<lang>' pairs the sync bot has actually written at least once."""
+    try:
+        state = json.loads(
+            (ROOT / TR_DIR / ".sync-state.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    return set(state.get("docs", {}))
+
+
 def check_mirror() -> list[str]:
     bad = []
+    synced = synced_pairs()
     for c in canonical_docs():
         for lang in LANGS:
             if lang == PRIMARY:
                 continue
             if not (ROOT / TR_DIR / lang / c).exists():
+                if f"{c}|{lang}" not in synced:
+                    continue  # bootstrap in flight — the nightly sync drains it
                 bad.append(f"{TR_DIR}/{lang}/{c}: missing mirror of {c}")
     for md in markdown_files():
         rel = md.relative_to(ROOT).as_posix()

--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -65,7 +65,13 @@ TIMEOUT_S = 300
 MAX_TOKENS = 8192
 MAX_CHARS = 40_000
 MAX_TASKS = 80
-MIN_LENGTH_RATIO = 0.55  # a translation this much shorter than its source lost content
+# A translation much shorter than its source has lost content — but the floor
+# is per-script: CJK packs the same content into roughly half the Latin
+# character count (the zh/ja bootstrap measured 45-51% on good translations),
+# so the generic floor would reject every CJK document forever.
+MIN_LENGTH_RATIO = 0.55
+MIN_LENGTH_RATIO_CJK = 0.25
+CJK_LANGS = {"zh", "ja", "ko"}
 BOT_MARKER = "[bot]"     # matches github-actions[bot] in both %an and %ae
 
 GLOSSARY = (
@@ -380,7 +386,7 @@ def seed_state() -> dict:
             twin = ROOT / tr_path(c, l)
             if not twin.exists():
                 continue
-            bad = implausible(text, twin.read_text(encoding="utf-8"), c)
+            bad = implausible(text, twin.read_text(encoding="utf-8"), c, l)
             if bad:
                 print(f"  ! {tr_path(c, l)}: {bad} — queued for re-translation")
                 continue
@@ -511,12 +517,13 @@ def doc_shape(text: str) -> tuple[int, int]:
             len(re.findall(r"(?m)^\|", text)))
 
 
-def implausible(src_text: str, out: str, name: str) -> str | None:
+def implausible(src_text: str, out: str, name: str, lang: str) -> str | None:
     """Reason the reply must not be written, or None when it looks like a real
     translation."""
-    if len(out) < MIN_LENGTH_RATIO * len(src_text):
+    ratio = MIN_LENGTH_RATIO_CJK if lang in CJK_LANGS else MIN_LENGTH_RATIO
+    if len(out) < ratio * len(src_text):
         return (f"{len(out)} chars against {len(src_text)} in the source "
-                f"(<{MIN_LENGTH_RATIO:.0%}) — content is missing")
+                f"(<{ratio:.0%}) — content is missing")
     if name.endswith(".md"):
         want, got = doc_shape(src_text), doc_shape(out)
         if want != got:
@@ -547,15 +554,19 @@ def translate_doc(src: str, dst: str, dst_lang: str, old_src: str, dry: bool) ->
     except BadReply as e:
         print(f"  ! {dst}: {e} — left stale, will be retried")
         return False
-    bad = implausible(text, out, dst)
+    bad = implausible(text, out, dst, dst_lang)
     if bad:
         print(f"  ! {dst}: {bad} — not written, will be retried")
         return False
     canon, _ = parse_doc(dst)
     if dst.endswith(".md"):
         primary_text = (ROOT / canon).read_text(encoding="utf-8") if (ROOT / canon).exists() else None
-        out = apply_langbar(out, canon, dst_lang)
+        # repair first, bar last: the deterministic bar must never go through
+        # the repair ladder — a bar link into a not-yet-bootstrapped mirror is
+        # "broken", and the ladder repoints it at whatever exists (usually the
+        # document itself)
         out = fix_asset_links(out, canon, dst_lang, primary_text)
+        out = apply_langbar(out, canon, dst_lang)
     dst_p.parent.mkdir(parents=True, exist_ok=True)
     dst_p.write_text(out.rstrip() + "\n", encoding="utf-8")
     return True
@@ -735,7 +746,8 @@ def refresh_langbars(dry: bool) -> int:
             if not p.exists():
                 continue
             text = p.read_text(encoding="utf-8")
-            new = fix_asset_links(apply_langbar(text, c, l), c, l, primary_text)
+            # same order as translate_doc: the bar goes on after link repair
+            new = apply_langbar(fix_asset_links(text, c, l, primary_text), c, l)
             if new != text:
                 n += 1
                 print(f"  ~ {tr_path(c, l)}")


### PR DESCRIPTION
## What broke

Adding `zh`/`ja` to i18n.json ([ef92831](https://github.com/zeloras/through-metal-link/commit/ef92831)) turned the pipeline red three ways at once — CI run [30540376392](https://github.com/zeloras/through-metal-link/actions/runs/30540376392), Translation sync run [30540376176](https://github.com/zeloras/through-metal-link/actions/runs/30540376176):

1. **The 0.55 length floor rejected every good CJK translation, forever.** CJK packs the same content into roughly half the Latin character count; the bootstrap measured 45–51% on translations the model got right (`zh/CONTRIBUTING.md` 46%, `zh/docs/00-theory.md` 45%, …). Those pairs would retry on every run and be thrown away on every run — the nightly cron could never converge.
2. **The repair ladder mangled langbar links into not-yet-written mirrors.** The bar was applied before `fix_asset_links`, which saw `../translations/zh/…` as broken and repointed it at whatever exists — usually the document itself (`[中文](00-theory.md)` in master right now), or left it broken (`hardware/driver/README.md`), failing the link invariant.
3. **check_repo failed every commit between "language declared" and "bootstrap finished"** — the race is inherent: mirrors are written by an asynchronous bot, so the commit adding a language can never carry them.

## The fix

- `translate_sync.py`: per-script length floor — 0.25 for `zh`/`ja`/`ko`, 0.55 for everything else. The structure check (headings + table rows must match the source) remains the real truncation guard.
- `translate_sync.py`: bars go on **after** link repair (both `translate_doc` and `refresh_langbars`), so the deterministic bar never passes through the repair ladder.
- `check_repo.py`: a missing mirror the sync has never recorded in `.sync-state.json` is a bootstrap in flight, not breakage; a recorded mirror that disappears still fails (verified). The langbar line is exempt from the link invariant — mirror completeness governs its targets.

## Aftermath in master this PR does not touch

The self-links in the langbars committed by the bot heal themselves: `refresh_langbars` rewrites every bar deterministically on the next sync run. The ~100 stale pairs (bar rewrite bumped every source hash) drain in two runs (80-task cap + 20).

## Verified locally

- `check_repo.py` green on current master state (13 pending mirrors tolerated, bar self-links skipped)
- deleting a state-recorded mirror still fails the mirror check
- `translate_sync.py --dry-run` unchanged plan, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)