### PR TITLE
fix: translation pipeline hardening (S1, S4-S7, S9, S11, S12)

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # OLLAMA_API_KEY is an environment secret, so the job must name it
-    environment: "1"
+    environment: "translation-sync"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -72,7 +72,7 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add translations/ hardware/schematics/labels.json software/simulator/labels.json translations/.sync-state.json
+          git add translations/ hardware/schematics/labels.json software/simulator/labels.json translations/.sync-state.json docs/img/ hardware/schematics/*.png hardware/schematics/*.svg
           git commit -s -m "sync translations and figures [translate-sync]"
           # a second push to master while this job was running left our checkout
           # one commit behind: rebase onto it instead of failing the sync

--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -67,7 +67,7 @@ MODEL = os.environ.get("TRANSLATE_MODEL", "glm-5.2")
 # a GitHub token must never be sent to it.
 TOKEN = os.environ.get("OLLAMA_API_KEY") or os.environ.get("OPENAI_API_KEY")
 TIMEOUT_S = 300
-MAX_TOKENS = 8192
+MAX_TOKENS = 16384
 MAX_CHARS = 40_000
 MAX_TASKS = 80
 # A translation much shorter than its source has lost content — but the floor
@@ -79,14 +79,21 @@ MIN_LENGTH_RATIO_CJK = 0.25
 CJK_LANGS = {"zh", "ja", "ko"}
 BOT_MARKER = "[bot]"     # matches github-actions[bot] in both %an and %ae
 
-GLOSSARY = (
+GLOSSARY_RU = (
     "ланжевен = Langevin transducer; свип-карта = sweep map; АЧХ = frequency response; "
     "гребёнка толщинных резонансов = comb of thickness resonances; ионистор = supercapacitor; "
     "мост Гретца/Шоттки = full-wave/Schottky bridge; нагрузочная модуляция = load modulation; "
     "обвязка = support passives; мёртвое время = dead time; струбцина = clamp; "
     "смазка = grease couplant; заваренная коробка = welded-shut box; врезка = penetration; "
-    "истёкшие патенты = expired patents; стенд = test rig; макет = breadboard prototype"
+    "истёкшиеся патенты = expired patents; стенд = test rig; макет = breadboard prototype"
 )
+
+
+def glossary_for(src_lang: str, dst_lang: str) -> str:
+    """Return the glossary block only when Russian is involved in the pair."""
+    if "ru" in (src_lang, dst_lang):
+        return GLOSSARY_RU
+    return ""
 
 
 class ModelUnavailable(Exception):
@@ -150,7 +157,12 @@ _TREE: dict[str, list[str]] | None = None
 
 def tree_index() -> dict[str, list[str]]:
     """basename -> canonical paths. Built once; no globbing, so a model-supplied
-    name full of glob metacharacters is just a dict miss."""
+    name full of glob metacharacters is just a dict miss.
+
+    Excludes the entire translations/ subtree (not just the root entry) so the
+    unique-basename fallback never resolves to a translation file instead of
+    the canonical original.
+    """
     global _TREE
     if _TREE is None:
         _TREE = {}
@@ -158,8 +170,11 @@ def tree_index() -> dict[str, list[str]]:
         for dirpath, dirnames, filenames in os.walk(ROOT):
             rel = Path(dirpath).relative_to(ROOT)
             at_root = rel == Path(".")
+            # prune __pycache__ everywhere; prune translations/ at any depth
             dirnames[:] = [d for d in dirnames
-                           if d != "__pycache__" and not (at_root and d in skip_top)]
+                           if d != "__pycache__"
+                           and not (at_root and d in skip_top)
+                           and TR_DIR not in rel.parts]
             for fn in filenames:
                 _TREE.setdefault(fn, []).append(fn if at_root else (rel / fn).as_posix())
     return _TREE
@@ -436,15 +451,16 @@ def save_state(state: dict, dry: bool) -> None:
 def udiff(old: str, new: str, name: str) -> str:
     return "".join(difflib.unified_diff(
         old.splitlines(keepends=True), new.splitlines(keepends=True),
-        fromfile=f"old/{name}", tofile=f"new/{name}"))[:8000]
+        fromfile=f"old/{name}", tofile=f"new/{name}"))[:20000]
 
 
 def system_doc(dst_lang: str) -> str:
+    glossary = glossary_for(PRIMARY, dst_lang)
+    glossary_line = f" Terminology (ru = en): {glossary}." if glossary else ""
     return f"""You are the translation-sync bot of an open-hardware repository
 (ultrasonic power/data through steel walls). The primary language is
 {NAMES[PRIMARY]}; every other language is a mirror tree under
-translations/<lang>/ with identical file names. Terminology (ru = en):
-{GLOSSARY}.
+translations/<lang>/ with identical file names.{glossary_line}
 
 Target language now: {NAMES[dst_lang]} ({dst_lang}).
 
@@ -465,8 +481,11 @@ Rules:
 - Return ONLY the full content of the target file. No code fences, no comments."""
 
 
-SYSTEM_JSON = f"""You translate UI label strings for an open-hardware project
-(ultrasonic power through steel). Terminology (ru = en): {GLOSSARY}.
+def system_json(src_lang: str, dst_lang: str) -> str:
+    glossary = glossary_for(src_lang, dst_lang)
+    glossary_line = f" Terminology (ru = en): {glossary}." if glossary else ""
+    return f"""You translate UI label strings for an open-hardware project
+(ultrasonic power through steel).{glossary_line}
 Input: a JSON object with strings in the source language. Return ONLY a JSON
 object with the same keys and translated values. Keep placeholders like {{d}},
 {{r}}, {{q}}, {{tau}}, units and part numbers intact — same placeholders, same
@@ -514,7 +533,7 @@ def chat(system: str, user: str) -> str:
                        f"{choice.get('finish_reason')!r}) — output would be truncated")
     if not isinstance(out, str) or not out.strip():
         raise BadReply("empty completion")
-    return re.sub(r"^```[a-z]*\n|\n```$", "", out.strip())  # guard against code fences
+    return re.sub(r"^.*?```[a-z]*\n|\n```\S*$", "", out.strip(), flags=re.DOTALL)  # guard against code fences
 
 
 # ---------- documents ----------
@@ -535,9 +554,14 @@ def implausible(src_text: str, out: str, name: str, lang: str) -> str | None:
     """Reason the reply must not be written, or None when it looks like a real
     translation."""
     ratio = MIN_LENGTH_RATIO_CJK if lang in CJK_LANGS else MIN_LENGTH_RATIO
-    if len(out) < ratio * len(src_text):
+    # absolute floor: very short docs can legitimately compress heavily in
+    # concise languages, so the ratio check is skipped below this threshold
+    if len(out) >= 30 and len(out) < ratio * len(src_text):
         return (f"{len(out)} chars against {len(src_text)} in the source "
                 f"(<{ratio:.0%}) — content is missing")
+    if len(out) < 30 and len(src_text) > 0 and len(out) < len(src_text) * 0.1:
+        return (f"{len(out)} chars against {len(src_text)} in the source "
+                f"(severe truncation) — content is missing")
     if name.endswith(".md"):
         want, got = doc_shape(src_text), doc_shape(out)
         if want != got:
@@ -669,7 +693,7 @@ def sync_labels(changed: list[str], base: str, new_langs: list[str],
             if dry:
                 return {}
             try:
-                raw = chat(SYSTEM_JSON, json.dumps(
+                raw = chat(system_json(a, b), json.dumps(
                     {"source_language": a, "target_language": b, "strings": delta},
                     ensure_ascii=False))
             except BadReply as e:


### PR DESCRIPTION
## Summary

Implements 8 fixes from the supplementary review of `through-metal-link` ([supplementary-review.md](https://github.com/zeloras/through-metal-link/files/)). These address issues missed by all three prior reviews (architecture, code quality, test coverage).

### CRITICAL

- **S1: Canonical figures not committed after regeneration** — The `git add` command in `translate.yml` was changed from `git add -A` to a specific file list (commit 4217c0e), which inadvertently excluded `docs/img/*.png` and `hardware/schematics/*.png`. When `labels.json` is updated, translation figures are regenerated and committed, but canonical figures keep showing old labels. **Fix:** Added canonical figure paths to the `git add` command.

### MEDIUM

- **S4: Russian-only glossary in all prompts** — The 16-term Russian glossary was injected into every translation prompt regardless of language pair, wasting ~200 tokens/request for non-Russian pairs. **Fix:** Made the glossary language-aware via `glossary_for(src_lang, dst_lang)` — only included when `ru` is the source or target language.

- **S5: udiff() truncation at 8K chars** — Large document diffs were truncated to 8000 characters, causing the model to miss changes past the boundary. **Fix:** Increased the limit to 20000.

- **S6: MAX_TOKENS too low for CJK** — 8192 tokens caps output at ~3000-4000 CJK characters; large CJK documents could be permanently untranslatable (discarded by `implausible()` and retried with the same limit). **Fix:** Increased to 16384.

- **S7: tree_index() includes translation subdirectories** — The unique-basename fallback could resolve to a translation file instead of the canonical original. **Fix:** Excluded the entire `translations/` subtree from `tree_index()` at any depth, not just the root entry.

### LOW

- **S9: implausible() false positive for very short documents** — `MIN_LENGTH_RATIO = 0.55` rejects valid translations of very short docs in concise languages. **Fix:** Added a 30-char absolute length floor below which the ratio check is skipped; added a 10% severe-truncation check for sub-30-char outputs.

- **S11: Code fence stripping regex too narrow** — Only handles fences at the very start/end of the output; conversational preambles (e.g. "Sure! Here is the translation:```...```") are not stripped. **Fix:** Made the regex handle non-fence text before the opening fence and after the closing fence using DOTALL.

- **S12: Environment named "1"** — The GitHub Actions environment is named `"1"`, which is unusual and potentially confusing. If it does not exist as a configured environment, the `OLLAMA_API_KEY` secret would not be available. **Fix:** Renamed to `"translation-sync"`.

## Files Changed

- `.github/workflows/translate.yml` — S1 (git add paths), S12 (environment name)
- `tools/translate_sync.py` — S4 (glossary), S5 (udiff limit), S6 (MAX_TOKENS), S7 (tree_index), S9 (implausible floor), S11 (code fence regex)

## Test Plan

- [x] Python syntax check passes (`py_compile`)
- [x] YAML validation passes
- [x] `ruff check` shows no new violations (6 pre-existing warnings unchanged)
- [ ] CI: repository invariants (`check_repo.py`) pass
- [ ] CI: no translation sync regressions
- [ ] After merge: verify the `translation-sync` environment exists in repo settings with `OLLAMA_API_KEY` configured (required for S12)

## Notes

- S2 (104 wrong-language labels.json entries) and S3 (orphaned translation files) require more complex fixes (language detection logic, cleanup pass) and are deferred to follow-up work.
- The environment rename (S12) requires a matching environment to be created in GitHub repo settings. If it does not exist, the job will fail to find the secret — but the current environment `"1"` is equally at risk. This should be verified before merge.

Closes #N/A (supplementary review task t_bd759568)