### PR TITLE
Fix: a missing API key reported success — nothing has translated since 11 August

### DIFF
--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -33,6 +33,8 @@ model via OPENAI_BASE_URL / TRANSLATE_MODEL — for a local daemon that is
 OPENAI_BASE_URL=http://localhost:11434/v1 with no key.
 
 Usage: python tools/translate_sync.py [--base <sha>] [--dry-run]
+       [--no-model] runs the deterministic passes only and exits 0;
+       without it, a missing API key is an error, not a warning.
 """
 
 import argparse
@@ -834,6 +836,9 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--base", default="HEAD~1", help="commit to diff against")
     p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--no-model", action="store_true",
+                   help="run only the deterministic passes (language bars, link "
+                        "repair); do not expect an API key")
     p.add_argument("--touched-list", metavar="PATH",
                    help="write the newline-separated list of paths this run "
                         "modified, for `git add --pathspec-from-file`")
@@ -856,9 +861,12 @@ def main() -> int:
         print(f"Bootstrapping: {', '.join(new_langs)}")
 
     if not TOKEN:
-        print("::warning::No OLLAMA_API_KEY or OPENAI_API_KEY set — "
-              "translations will not run, stale files stay queued")
-        # still refresh langbars and save state so the repo invariants pass
+        # An unreachable endpoint is transient and must not fail the pipeline —
+        # that is what ModelUnavailable is for. No key at all is not transient,
+        # it is a misconfiguration, and treating the two alike hid one for three
+        # days: the workflow's `environment:` was renamed without moving the
+        # secret, every run reported success, and nothing was translated the
+        # whole time. Pass --no-model to run the deterministic passes on purpose.
         total = 0
         try:
             total += refresh_langbars(a.dry_run)
@@ -868,7 +876,16 @@ def main() -> int:
                 Path(a.touched_list).write_text(
                     "".join(f"{p}\n" for p in sorted(WRITTEN)), encoding="utf-8")
         print(f"Synced: {total}")
-        return 0
+        if a.no_model or a.dry_run:
+            print("No API key; deterministic passes only, as requested.")
+            return 0
+        print("::error::No OLLAMA_API_KEY or OPENAI_API_KEY reached this job — "
+              "nothing was translated and every stale pair stays queued. Check "
+              "that the secret exists in the environment the job declares: an "
+              "environment secret is only visible to a job naming that exact "
+              "environment. Use --no-model if this run was meant to be "
+              "deterministic-only.")
+        return 1
 
     total = 0
     try:


### PR DESCRIPTION
No new language directories appeared because **nothing has been translated since 11 August**, and every run said it succeeded.

## Cause

`OLLAMA_API_KEY` exists in the environment named `1`. The job declares `environment: "translation-sync"`. An environment secret is visible only to a job naming that exact environment, so `${{ secrets.OLLAMA_API_KEY }}` has expanded to the empty string. The run log shows it plainly: `OLLAMA_API_KEY:` with nothing after it.

Timeline from the workflow's own history:

| when | what |
|---|---|
| 5 Aug (`bbbbf5f`) | moved off the retired GitHub Models to Ollama; `environment: "1"`, secret created there — working |
| 5–10 Aug | real translations land (`51f1748`, `5bdd5fc`, `5332589`, `4b0abb1`) |
| 11 Aug (`817805d`, "pipeline hardening") | `environment: "1"` → `"translation-sync"`; the secret was not moved |
| 11 Aug 03:53 | first run after that auto-creates the empty `translation-sync` environment |
| since | key empty, no translations — including the nine-language bootstrap |

The secret side is yours to fix (I have no access to the value): add `OLLAMA_API_KEY` to the `translation-sync` environment. This PR does not touch the workflow's environment binding.

## What this PR changes

A missing key took the same code path as an unreachable endpoint: warn, keep the queue, exit 0. That is right for an outage — the state file means nothing is lost and the next run resumes exactly where it stopped — but a key that was never configured is not an outage. Treating them alike is precisely what let three days of silence look like three days of green checks, and it is the reason this had to be noticed by hand rather than by CI.

Missing key now exits 1 **after** still running the deterministic passes, so the language bars and the state file are still committed (the commit step runs under `if: always()`) while the job goes red. `--no-model` asks for deterministic-only on purpose and keeps exit 0 — what a contributor refreshing bars locally wants.

Verified all three states: no key → exit 1 with the diagnostic; no key + `--no-model` → exit 0; key present → normal path.

## After the secret lands

289 stale pairs are queued, drained 80 per run — the nine new trees fill in over roughly four nightly runs, or immediately if you dispatch the workflow by hand. `check_repo` tolerates a bootstrap in flight, so a partly-filled tree does not turn CI red.

## Verification

`check_repo` green, `compileall` clean.