### PR TITLE
Fix: Ollama rejects the key with 401, and the run still reported success

### DIFF
--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -69,7 +69,8 @@ ENDPOINT = os.environ.get("OPENAI_BASE_URL", "https://ollama.com/v1")
 MODEL = os.environ.get("TRANSLATE_MODEL", "glm-5.2")
 # Deliberately no GITHUB_TOKEN fallback: the endpoint is now a third party, and
 # a GitHub token must never be sent to it.
-TOKEN = os.environ.get("OLLAMA_API_KEY") or os.environ.get("OPENAI_API_KEY")
+TOKEN = (os.environ.get("OLLAMA_API_KEY") or os.environ.get("OPENAI_API_KEY")
+         or "").strip()  # a secret pasted with stray whitespace still authenticates
 TIMEOUT_S = 300
 MAX_TOKENS = 16384
 MAX_CHARS = 40_000
@@ -114,6 +115,17 @@ class BadReply(Exception):
     batch, an unexpected envelope. Only the current item is skipped; it stays
     stale and gets another go next run. Never written to disk: that is how
     translations/pt/README.md ended up a 478-byte stub cut off mid-link.
+    """
+
+
+class AuthRejected(Exception):
+    """The endpoint rejected the credentials (401/403).
+
+    Kept apart from ModelUnavailable on purpose. An outage is weather: warn,
+    keep the queue, exit 0, and the next run resumes. A key the provider
+    refuses is a misconfiguration that will refuse every future run too, and
+    reporting it as success is how three days of translating nothing looked
+    like three days of green checks.
     """
 
 
@@ -530,8 +542,10 @@ def chat(system: str, user: str) -> str:
                 print(f"  ! HTTP {e.code}, retrying in {wait}s...")
                 time.sleep(wait)
                 continue
-            raise ModelUnavailable(
-                f"HTTP {e.code}: {e.read().decode(errors='replace')[:300]}") from e
+            body = e.read().decode(errors="replace")[:300]
+            if e.code in (401, 403):
+                raise AuthRejected(f"HTTP {e.code}: {body}") from e
+            raise ModelUnavailable(f"HTTP {e.code}: {body}") from e
         except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as e:
             raise ModelUnavailable(f"transport error: {e}") from e
         except json.JSONDecodeError as e:
@@ -888,6 +902,7 @@ def main() -> int:
         return 1
 
     total = 0
+    auth_failed: AuthRejected | None = None
     try:
         # phase 1 — non-primary edits flow back into the primary file first, so
         # phase 2 hashes below are taken from the up-to-date primary
@@ -907,6 +922,8 @@ def main() -> int:
                 state["docs"][f"{c}|{l}"] = h
 
         total += sync_labels(changed, base, new_langs, state, a.dry_run)
+    except AuthRejected as e:
+        auth_failed = e
     except ModelUnavailable as e:
         # keep everything already translated; the state file still marks the
         # rest as stale, so the next push or the nightly run picks it up
@@ -920,6 +937,13 @@ def main() -> int:
             print(f"Touched {len(WRITTEN)} path(s) -> {a.touched_list}")
 
     print(f"Synced: {total}")
+    if auth_failed is not None:
+        print(f"::error::{ENDPOINT} rejected the credentials ({auth_failed}). "
+              "Nothing was translated and every stale pair stays queued. The key "
+              "reached the job, so this is the value itself — check that the "
+              "secret holds a current key for this endpoint and that "
+              "TRANSLATE_MODEL is one the account may use.")
+        return 1
     return 0
 
 


### PR DESCRIPTION
I dispatched the sync by hand after your merge. It ran, and the log gives the real answer:

```
Bootstrapping: es, fr, it, pl, tr, uk, vi, ko, hi
289 stale pairs — doing 80 now, 209 left for the next run
##[warning]Model unavailable (HTTP 401: {"error":{"message":"Unauthorized"}})
Synced: 0
```

Two separate things.

## Why nothing ran on the merge

`translate.yml` triggers on push only for `**/*.md`, `**/*.csv`, `**/labels.json`, `i18n.json`. PR #15 changed one file, `tools/translate_sync.py`, which matches none of them — so the workflow was correctly never triggered. Not a fault; there was simply nothing to fire it. Manual `workflow_dispatch` and the nightly cron are the other two entry points.

## Why the dispatched run still translated nothing

The secret now reaches the job — it got past the missing-key check added in #15 and made a real request. **The endpoint refused the value: HTTP 401 Unauthorized.** That part is yours: the key in `translation-sync` needs to be a current Ollama Cloud key valid for `https://ollama.com/v1`, and `TRANSLATE_MODEL` (`glm-5.2`) has to be one the account may use.

## What this PR changes

401 fell into `ModelUnavailable`, alongside timeouts and 5xx — warn, keep the queue, exit 0. That is correct for an outage: the state file means nothing is lost and the next run resumes exactly where this one stopped. Credentials the provider refuses are not an outage. They will refuse every future run identically, and reporting it as success is the same failure mode as the missing secret was — a green check over a pipeline doing nothing. That is twice now that "success" meant "did nothing", which is why this is worth separating rather than patching case by case.

401 and 403 now raise `AuthRejected` and exit 1, after the deterministic passes have run and been committed. 429 and 5xx keep their retry-then-warn behaviour untouched.

The token is also `.strip()`ed. A secret pasted with a trailing newline is a plausible route to exactly this 401 and costs nothing to rule out — worth trying before regenerating the key.

Verified against a local endpoint returning 401 (exit 1, diagnostic naming the endpoint) and one returning 503 (exit 0, queue preserved).

## After a working key

289 stale pairs, 80 per run — the nine trees fill over about four runs, or dispatch repeatedly. `check_repo` tolerates a bootstrap in flight.

## Verification

`check_repo` green, `compileall` clean.