### PR TITLE
Fix: bootstrap sent each document to the model twice, so the big ones came back summarised

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -3,7 +3,10 @@ name: Translation sync
 on:
   push:
     branches: [master]
-    paths: ["**/*.md", "**/*.csv", "**/labels.json", "i18n.json"]
+    # tools/** is here because a change to the sync itself changes its output:
+    # merging a fix for the translator and having nothing happen, twice in a
+    # row, is not a useful default.
+    paths: ["**/*.md", "**/*.csv", "**/labels.json", "i18n.json", "tools/**"]
   # drains the backlog: anything the model could not finish (quota, timeout,
   # per-run cap) stays marked stale in translations/.sync-state.json and is
   # picked up here without waiting for the next doc edit

--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -613,18 +613,48 @@ def translate_doc(src: str, dst: str, dst_lang: str, old_src: str, dry: bool) ->
     if dry:
         return True
     old_dst = dst_p.read_text(encoding="utf-8")[:MAX_CHARS] if dst_p.exists() else "(missing)"
-    try:
-        out = chat(system_doc(dst_lang), (
-            f"Source file `{src}` — NEW content:\n<<<\n{text}\n>>>\n\n"
-            f"What changed in the source (unified diff):\n<<<\n{udiff(old_src, text, src)}\n>>>\n\n"
-            f"Target file `{dst}` — CURRENT (possibly outdated or missing) content:\n"
-            f"<<<\n{old_dst}\n>>>\n\n"
-            "Produce the full updated target file, reflecting every change from the diff."))
-    except BadReply as e:
-        print(f"  ! {dst}: {e} — left stale, will be retried")
-        return False
-    bad = implausible(text, out, dst, dst_lang)
-    if bad:
+    # A bootstrap has no previous source, so udiff() re-emits the entire file as
+    # additions: the document goes into the prompt twice and is then framed as a
+    # change set to "reflect". The two largest documents came back as summaries
+    # in all fourteen languages because of it — README.md at a ~27 kB prompt and
+    # CONTRIBUTING.md at ~17 kB, while everything at 13 kB and below translated
+    # cleanly. With no previous version there is nothing to diff against, so ask
+    # for a plain full translation and send the source once.
+    diff = udiff(old_src, text, src) if old_src.strip() else ""
+    if diff:
+        task = (f"What changed in the source (unified diff):\n<<<\n{diff}\n>>>\n\n"
+                f"Target file `{dst}` — CURRENT (possibly outdated) content:\n"
+                f"<<<\n{old_dst}\n>>>\n\n"
+                "Produce the full updated target file, reflecting every change "
+                "from the diff.")
+    else:
+        task = ("Translate the source file above into the target language in "
+                "full. Reproduce every heading, table row, list item and code "
+                "block: the result must mirror the structure of the source, "
+                "not summarise it.")
+
+    out = None
+    for attempt in (1, 2):
+        try:
+            out = chat(system_doc(dst_lang),
+                       f"Source file `{src}` — content:\n<<<\n{text}\n>>>\n\n{task}")
+        except BadReply as e:
+            print(f"  ! {dst}: {e} — left stale, will be retried")
+            return False
+        bad = implausible(text, out, dst, dst_lang)
+        if not bad:
+            break
+        if attempt == 1:
+            # one corrective attempt naming the shortfall, rather than burning
+            # the pair until a nightly run happens to get a better sample
+            print(f"  ~ {dst}: {bad} — retrying with the structure spelled out")
+            want = doc_shape(text)
+            task = (f"Translate the source file above in full. Your previous "
+                    f"reply was rejected: {bad}. The source has {want[0]} "
+                    f"markdown heading(s) and {want[1]} table row(s); the "
+                    f"translation must have exactly the same. Translate every "
+                    f"section — do not summarise, omit or merge any of them.")
+            continue
         print(f"  ! {dst}: {bad} — not written, will be retried")
         return False
     canon, _ = parse_doc(dst)


### PR DESCRIPTION
Your new key works. I dispatched the sync and it translated **70 of 80 pairs** — `translations/es`, `fr`, `it`, `pl`, `tr`, `uk`, `vi`, `ko`, `hi` now exist on master.

The 10 it refused were not random.

## What failed, and why it would never have recovered

`README.md` and `CONTRIBUTING.md`, in all fourteen languages, all rejected as `content is missing`. Everything else went through. The split is by size and it is exact:

| document | chars | prompt sent | outcome |
|---|---|---|---|
| README.md | 13 680 | ~27 kB | rejected ×14 |
| CONTRIBUTING.md | 8 559 | ~17 kB | rejected ×14 |
| LICENSES.md | 6 383 | ~13 kB | ok |
| QUICKSTART.md | 6 107 | ~12 kB | ok |
| everything else | < 6 000 | < 12 kB | ok |

A bootstrap has no previous source, so `udiff()` re-emitted the whole file as additions. The document went into the prompt **twice** — once as itself, once as a "unified diff" — and the instruction was to reflect every change from that diff. The largest prompts came back as summaries. `finish_reason` was `stop`, so this was not truncation at the token ceiling: the model condensed rather than translated.

The plausibility guard did exactly its job and refused to write a partial document. But those pairs would have stayed stale **forever**, because every retry rebuilt the identical prompt. A permanent stall on the two most important documents in the repository.

## Fix

With no previous version there is nothing to diff against, so the diff is dropped and the request becomes a plain full translation with the structure spelled out — halving the prompt and removing the framing that invited a summary.

A rejected reply now also gets **one corrective retry** naming the shortfall and the exact heading and table-row counts, rather than burning the pair until some nightly run happens to sample better.

Verified against a local endpoint: the bootstrap prompt carries no diff section and one copy of the source; a deliberately truncated first reply is rejected; the retry names the counts; the faithful second reply is written.

## Also

`tools/**` joins the push `paths` filter. Merging a translator fix and having nothing happen is what you hit twice — PRs #15 and #16 both changed only `tools/translate_sync.py`, which matched none of the filter's patterns, so no sync was triggered either time. A change to the translator changes its output; it should run.

## After merge

This one *will* trigger a sync on merge. 209 pairs remain queued at 80 per run, so expect the rest to fill in over the next couple of runs — the two big documents included, now that they can succeed.

## Verification

`check_repo` green, `compileall` clean, workflow YAML parses.