### PR TITLE
Fix: the language bar was being counted as content, failing the last two documents

### DIFF
--- a/tools/translate_sync.py
+++ b/tools/translate_sync.py
@@ -595,7 +595,11 @@ def split_sections(text: str) -> list[str] | None:
     lines = text.splitlines(keepends=True)
     heads = [i for i, l in enumerate(lines) if l.startswith("## ")]
     if len(heads) < 2:
-        return None
+        # No subsections, but the fallback is still worth having: a short
+        # document that merely lost its H1 (zh dropped one) is repaired by the
+        # same heading-batch path, with the document itself as the only section.
+        _, title, _ = _section_head(text)
+        return [text] if title else None
     chunks = []
     if heads[0]:
         chunks.append("".join(lines[:heads[0]]))       # preamble: H1, intro
@@ -686,17 +690,34 @@ def _split_oversized(chunk: str) -> list[str]:
     return [c for c in out if c.strip()]
 
 
+BAR_RE = re.compile(r"(?m)^> .*·.*$")
+
+
+def without_bar(text: str) -> str:
+    """Drop the language-switcher line before weighing a translation.
+
+    The bar is machine-generated and apply_langbar() rewrites it whatever the
+    model returns, so it is not content. It also grows with the language count:
+    at fifteen languages it is 923 of the 1996 characters of
+    hardware/schematics/README.md, so a good translation scored 41% against the
+    source and was discarded. The same reply scores 77% once the bar is out.
+    """
+    return BAR_RE.sub("", text)
+
+
 def implausible(src_text: str, out: str, name: str, lang: str) -> str | None:
     """Reason the reply must not be written, or None when it looks like a real
     translation."""
     ratio = MIN_LENGTH_RATIO_CJK if lang in CJK_LANGS else MIN_LENGTH_RATIO
+    # the language bar is not content — see without_bar()
+    src_body, out_body = without_bar(src_text), without_bar(out)
     # absolute floor: very short docs can legitimately compress heavily in
     # concise languages, so the ratio check is skipped below this threshold
-    if len(out) >= 30 and len(out) < ratio * len(src_text):
-        return (f"{len(out)} chars against {len(src_text)} in the source "
-                f"(<{ratio:.0%}) — content is missing")
-    if len(out) < 30 and len(src_text) > 0 and len(out) < len(src_text) * 0.1:
-        return (f"{len(out)} chars against {len(src_text)} in the source "
+    if len(out_body) >= 30 and len(out_body) < ratio * len(src_body):
+        return (f"{len(out_body)} chars against {len(src_body)} in the source "
+                f"(<{ratio:.0%}, language bar excluded) — content is missing")
+    if len(out_body) < 30 and len(src_body) > 0 and len(out_body) < len(src_body) * 0.1:
+        return (f"{len(out_body)} chars against {len(src_body)} in the source "
                 f"(severe truncation) — content is missing")
     if name.endswith(".md"):
         want, got = doc_shape(src_text), doc_shape(out)


### PR DESCRIPTION
The scheduled run you linked is good news wrapped around one self-inflicted bug.

## The heading fix worked

`README.md` and `CONTRIBUTING.md` now translate in every language — the two documents that had resisted every attempt. Coverage is **18/20 on all nine new languages**, 20/20 on ru, de, pt, zh, ja.

## The last two are my guard's fault

`hardware/schematics/README.md` and `software/sweep-map/README.md` were rejected as `content is missing`. They were not. The translations were fine.

The language bar is machine-generated — `apply_langbar()` rewrites it after every translation regardless of what the model returned — so it is not content. It is also the one part of a document that **grows with the language count**. At fifteen languages:

| | chars |
|---|---|
| `hardware/schematics/README.md` | 1 996 |
| its language bar | 923 (46% of the file) |
| the body that is actually translated | 1 073 |

A model that sensibly did not reproduce a 923-character bar of relative links scored 827/1996 = **41%** on the length check and was thrown away. Measured against the body, the same reply is **77%** — comfortably fine.

This did not show up earlier because at five languages the bar was ~300 characters and stayed under the noise. It appeared exactly when the language count tripled, and only on the shortest documents.

The three replies the run rejected are accepted now. A 237-character reply for the same document is still refused, and so is a 150-character one — the guard still does its job, it just no longer weighs its own output.

## One more path opened

`split_sections` returned `None` for anything with fewer than two `## ` headings, so a short document that merely dropped its H1 — zh did on this one — had no route back and simply failed. It now yields the document as a single section, which the heading-batch path repairs exactly as it repairs a long one.

## Verification

Against the stub that condenses long input and eats heading markers: README `(6, 11)`, CONTRIBUTING `(6, 0)`, hardware/schematics/README `(1, 6)` — each matching its source exactly. `check_repo` green, `compileall` clean.

## After merge

Merging triggers a sync. That should be the last of it — 20/20 across all fourteen. I will confirm.