### PR TITLE
Fix: figures were never staged, and had stopped being rendered at all

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -6,7 +6,11 @@ on:
     # tools/** is here because a change to the sync itself changes its output:
     # merging a fix for the translator and having nothing happen, twice in a
     # row, is not a useful default.
-    paths: ["**/*.md", "**/*.csv", "**/labels.json", "i18n.json", "tools/**"]
+    # the workflow file is here for the same reason tools/** is: a change to
+    # how the sync runs changes what it produces, and merging such a change to
+    # no effect is a trap this repository has already fallen into twice
+    paths: ["**/*.md", "**/*.csv", "**/labels.json", "i18n.json", "tools/**",
+            ".github/workflows/translate.yml"]
   # drains the backlog: anything the model could not finish (quota, timeout,
   # per-run cap) stays marked stale in translations/.sync-state.json and is
   # picked up here without waiting for the next doc edit

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -59,16 +59,18 @@ jobs:
           python tools/translate_sync.py --base "${{ github.event.before }}" \
             --touched-list "$RUNNER_TEMP/touched.txt"
 
-      # regenerate figures ONLY when the sync itself translated labels.json:
-      # human pushes never trigger a cross-platform re-render (macOS and the
-      # runner produce different PNG bytes — that would be endless churn)
-      - name: Regenerate figures if the sync updated labels.json
+      # Always render. The old gate ran the renderers only when this sync had
+      # just changed labels.json, which meant a language whose labels landed in
+      # an earlier run never got figures at all — eight of them had none. The
+      # gate existed to stop macOS-rendered bytes fighting runner-rendered
+      # bytes, but this job only ever runs on the runner with a pinned
+      # toolchain, so re-rendering unchanged labels reproduces the same bytes
+      # and stages nothing.
+      - name: Render figures
         if: always()
         run: |
-          if git status --porcelain | grep -q 'labels\.json'; then
-            python software/simulator/channel_sim.py --out docs/img
-            python hardware/schematics/render_schematics.py
-          fi
+          python software/simulator/channel_sim.py --out docs/img
+          python hardware/schematics/render_schematics.py
 
       # always(): a run that died halfway still produced valid translations, and
       # the state file records exactly what got done — dropping them would mean
@@ -92,9 +94,21 @@ jobs:
           if [ -s "$RUNNER_TEMP/touched.txt" ]; then
             git add --pathspec-from-file="$RUNNER_TEMP/touched.txt"
           fi
-          # figures come from the renderers, which are separate processes
-          git add docs/img/ hardware/schematics/*.png hardware/schematics/*.svg \
-                  'translations/*/docs/img' 'translations/*/hardware/schematics' 2>/dev/null || true
+          # Figures come from the renderers, which are separate processes and so
+          # are not in touched.txt. Iterate real directories rather than passing
+          # a wildcard pathspec: `git add 'translations/*/docs/img'` is a fatal
+          # "did not match any files" — a glob pathspec matches whole paths, not
+          # directory prefixes — and because that fatal aborted the whole
+          # command, no figure was ever staged, not even docs/img. The 2>/dev/null
+          # is gone too; that is what kept it invisible.
+          for d in docs/img hardware/schematics \
+                   translations/*/docs/img translations/*/hardware/schematics; do
+            if [ -d "$d" ]; then git add -- "$d"; fi
+          done
+          if git diff --cached --quiet; then
+            echo "Nothing staged — working tree changes were all outside the sync's scope"
+            exit 0
+          fi
           git commit -s -m "sync translations and figures [translate-sync]"
           # a second push to master while this job was running left our checkout
           # one commit behind: rebase onto it instead of failing the sync


### PR DESCRIPTION
**Documents: 20/20 on all fourteen languages.** Verified beyond file counts — 0 structural mismatches across all 280 mirrors (heading and table-row counts match their sources exactly), every section in the right script, `check_repo` green, translation queue empty.

| | |
|---|---|
| ru, de, pt, zh, ja | 20/20 |
| es, fr, it, pl, tr, uk, vi, ko, hi | 20/20 |

The last sync ran 28 pairs with **0 rejections** — the language-bar fix cleared the final two documents.

## What is not done: figures

Eight languages have no figures at all (`es, fr, it, pl, tr, uk, vi, ko`; `hi` is skipped on purpose). Two faults, both in this workflow.

**Staging.** `git add 'translations/*/docs/img'` is a **fatal** `did not match any files`. A glob pathspec matches whole paths, not directory prefixes, and the directory is not a path any file has — verified in a scratch repo. Because the fatal aborted the whole command, *nothing on that line was ever staged*: not the mirrors, not `docs/img`, not `hardware/schematics`. The `2>/dev/null || true` on the end is what kept it invisible on every run. Directories are now iterated in the shell and added literally, and errors are no longer swallowed.

**Rendering.** The renderers only ran when that same sync had just changed `labels.json`. Every new language's labels landed in a single run, the render did fire there — the log shows `OK: 84 PNG (en+ru+de+…+ko)` — and its output was then dropped by the staging bug. Nothing has touched `labels.json` since, so those figures would never have been produced again. They now render every run. The gate existed to stop macOS-rendered bytes fighting runner-rendered bytes, but this job only ever runs on the runner with a pinned toolchain, so re-rendering unchanged labels reproduces identical bytes and stages nothing.

## Verification

Ran both renderers locally: full sets for all fourteen figure-bearing languages, `hi` skipped by `render.skip_figures` as intended. Locally rendered bytes reverted — CI owns those. Workflow YAML parses; a staged-empty guard added so an unstageable tree reports it rather than failing on `git commit`.

## After merge

Merging triggers a sync, which will render and — this time — actually commit ~112 figures across the eight languages. I will confirm the full picture once it lands.