### PR TITLE
Fix the nightly figure churn: matplotlib's SVG writer is not reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
       - name: Schematics
         run: python hardware/schematics/render_schematics.py
 
+      # A byte that differs between two identical renders is a byte the nightly
+      # translation sync commits forever: matplotlib stamped a wall-clock date
+      # and per-process clip-path ids into every SVG, and that job dutifully
+      # recommitted all 56 schematics every night with no content change.
+      # render_schematics.py pins both — this is what keeps them pinned.
+      - name: Schematics render reproducibly
+        run: |
+          find hardware/schematics translations -path '*schematics*' \
+               \( -name '*.svg' -o -name '*.png' \) | sort \
+            | xargs sha256sum > "$RUNNER_TEMP/figures.sha256"
+          python hardware/schematics/render_schematics.py
+          sha256sum -c --quiet "$RUNNER_TEMP/figures.sha256"
+
       - name: Artifacts (all generated figures)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -69,7 +69,10 @@ jobs:
       # gate existed to stop macOS-rendered bytes fighting runner-rendered
       # bytes, but this job only ever runs on the runner with a pinned
       # toolchain, so re-rendering unchanged labels reproduces the same bytes
-      # and stages nothing.
+      # and stages nothing. That last clause held for PNG and was false for SVG:
+      # matplotlib stamps a wall-clock date and per-process clip-path ids into
+      # every SVG, so this step recommitted all 56 schematics every night with no
+      # content change until render_schematics.py pinned both.
       - name: Render figures
         if: always()
         run: |

--- a/hardware/schematics/render_schematics.py
+++ b/hardware/schematics/render_schematics.py
@@ -20,11 +20,31 @@ Output: PNG+SVG.
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+import matplotlib
+
 import schemdraw
 import schemdraw.elements as elm
+
+# The rendered figures are committed, so their bytes have to be a function of
+# labels.json and this file — nothing else. Matplotlib's SVG writer breaks that
+# twice over: it stamps every file with the wall-clock render time, and it salts
+# the clip-path ids it generates from a per-process seed, so two identical runs
+# differ in ~86 lines per schematic. That is why the nightly sync rewrote all 56
+# schematic SVGs every night with no content change — the job was not comparing
+# anything wrongly, it was staging real byte differences. PNG output has neither
+# property, which is why only the SVGs churned.
+#
+# Both knobs below are documented matplotlib behaviour, and both have to be set
+# here: schemdraw's save() forwards neither (it calls savefig with a fixed
+# argument list, so metadata={'Date': None} cannot be passed through). The
+# environment variable is read at savefig time, not at import, so it does not
+# have to precede the imports above.
+os.environ["SOURCE_DATE_EPOCH"] = "0"  # -> <dc:date>1970-01-01T00:00:00+00:00</dc:date>
+matplotlib.rcParams["svg.hashsalt"] = "through-metal-link"
 
 OUT = Path(__file__).resolve().parent
 REPO_ROOT = OUT.parents[1]


### PR DESCRIPTION
## What does this PR change?

Pins the two sources of non-determinism in matplotlib's SVG output, so the nightly translation sync stops recommitting all 56 schematic SVGs every night with no content change.

## The symptom

Every night at 03:3x, one commit, always the same shape:

```
56 files changed, 3290 insertions(+), 3290 deletions(-)
```

Eleven nights in a row (`b08fdc2`, `73d5d95`, `ebb8d7e`, `1a7a601`, `4131fd4`, …). Only `.svg`, only under `hardware/schematics/` and `translations/*/hardware/schematics/` — 4 primary + 13 mirrors × 4 (`hi` is in `skip_figures`). Never `.md`, never `docs/img`.

## The cause — not the comparison, the renderer

The sync job is behaving correctly: it stages the figure directories and commits whatever differs, and the bytes genuinely differed. Matplotlib's SVG writer is not reproducible by default:

1. **`<dc:date>`** — every file is stamped with the wall-clock render time.
2. **Clip-path ids** — `url(#pb897b0c0c0)` → `url(#p6524715e0f)`, salted from a per-process seed. ~85 references per file.

That is the whole diff: one date line plus the clip-path ids. Normalising both away shows the committed SVGs and freshly rendered ones are otherwise **identical** — nothing about the drawings ever changed.

PNG output has neither property, which is exactly why only the SVGs churned and `docs/img` never did.

## The fix

```python
os.environ["SOURCE_DATE_EPOCH"] = "0"   # -> <dc:date>1970-01-01T00:00:00+00:00</dc:date>
matplotlib.rcParams["svg.hashsalt"] = "through-metal-link"
```

Both are documented matplotlib behaviour, and both have to be set in the renderer rather than at the call site: `schemdraw`'s `save()` calls `savefig` with a fixed argument list and forwards neither, so `metadata={'Date': None}` cannot be passed through. `SOURCE_DATE_EPOCH` is read at savefig time, not at import, so the lines sit with the rest of the module setup.

## Verification

- Two consecutive full renders of all 15 languages: **112 files (56 SVG + 56 PNG) byte-identical**. Before the change, every SVG differed between runs and every PNG already matched.
- Content equivalence checked by normalising the date and ids: no drawing changes.

## Why the figures are not re-rendered in this PR

Committed figure bytes come from the runner, with the pinned toolchain and its Noto fonts. A macOS render differs in all 56 PNGs — the exact "macOS-rendered bytes fighting runner-rendered bytes" the `translate.yml` comment warns about. **Expect one final 56-file sync commit after merge**, produced on the runner, and then silence.

## Also in this PR

- **`translate.yml`** — the comment above the render step asserted that re-rendering unchanged labels "reproduces the same bytes and stages nothing". True for PNG, false for SVG; that wrong assumption is how this survived unnoticed. Corrected in place.
- **`ci.yml`** — a step that renders twice and compares hashes, so the next non-reproducible writer fails a PR instead of quietly filling the nightly log.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — the DCO check is mandatory ([CONTRIBUTING.md](https://github.com/zeloras/through-metal-link/blob/master/CONTRIBUTING.md) §2)
- [x] Design decisions trace back to expired patents / papers from [docs/01-prior-art.md](https://github.com/zeloras/through-metal-link/blob/master/docs/01-prior-art.md) (§3) — n/a, tooling only
- [x] Code comments, identifiers and commit messages are in English (§3)
- [ ] Experiments follow [experiments/TEMPLATE.md](https://github.com/zeloras/through-metal-link/blob/master/experiments/TEMPLATE.md) — n/a, no experiment

## Languages

No documentation touched — nothing for the translation bot to mirror.