### PR TITLE
Sync: check the invariants before the push, not after it

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -82,11 +82,32 @@ jobs:
       # always(): a run that died halfway still produced valid translations, and
       # the state file records exactly what got done — dropping them would mean
       # paying the model again for the same work
+      # Before the commit, deliberately. The bot pushes with GITHUB_TOKEN, which
+      # by design triggers no CI, so this is the only gate master ever gets —
+      # and it used to run last, which made it a post-mortem rather than a gate:
+      # run 33307609143 translated thirteen dead anchors, pushed them to master
+      # and only then went red. continue-on-error keeps the result available to
+      # the commit step instead of ending the job here, because the work is paid
+      # for and must be preserved either way.
+      - name: Repository invariants
+        id: invariants
+        if: always()
+        continue-on-error: true
+        run: python tools/check_repo.py
+
       - name: Commit the result
         if: always()
         run: |
           if git diff --quiet && [ -z "$(git status --porcelain)" ]; then
             echo "Nothing to sync"
+            # A clean tree that fails the invariants means the breakage is
+            # already committed on the branch and no sync will heal it. Staying
+            # green here would hide it until the next unrelated change.
+            if [ "${{ steps.invariants.outcome }}" != "success" ]; then
+              echo "::error::Nothing to sync, but check_repo failed on the tree as"\
+                   "checked out: ${GITHUB_REF_NAME} is broken independently of this run."
+              exit 1
+            fi
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -114,9 +135,28 @@ jobs:
           done
           if git diff --cached --quiet; then
             echo "Nothing staged — working tree changes were all outside the sync's scope"
+            if [ "${{ steps.invariants.outcome }}" != "success" ]; then
+              echo "::error::Nothing staged, but check_repo failed:"\
+                   "${GITHUB_REF_NAME} is broken independently of this run."
+              exit 1
+            fi
             exit 0
           fi
           git commit -s -m "sync translations and figures [translate-sync]"
+          # The gate. An invalid tree is still committed — the model was paid for
+          # this work and throwing it away means paying again — but it goes to a
+          # branch a human can inspect, rebase or cherry-pick, never to
+          # ${GITHUB_REF_NAME}. The run id keeps the name unique, so no rescue
+          # branch ever overwrites another.
+          if [ "${{ steps.invariants.outcome }}" != "success" ]; then
+            rescue="sync-rescue/${{ github.run_id }}"
+            git push origin "HEAD:refs/heads/$rescue"
+            echo "::error::check_repo failed on this tree, so it was NOT pushed to"\
+                 "${GITHUB_REF_NAME}. The work is preserved on branch $rescue —"\
+                 "fix the invariants there and merge it, or drop the branch and let"\
+                 "the next sync redo the pairs (the state file rides along with it)."
+            exit 1
+          fi
           # a second push to master while this job was running left our checkout
           # one commit behind: rebase onto it instead of failing the sync
           for attempt in 1 2 3; do
@@ -128,8 +168,3 @@ jobs:
           done
           git push origin HEAD:${GITHUB_REF_NAME}
 
-      # the bot pushes with GITHUB_TOKEN, which by design does not trigger CI —
-      # so the invariants have to be enforced here or not at all
-      - name: Repository invariants
-        if: always()
-        run: python tools/check_repo.py


### PR DESCRIPTION
## What does this PR change?

Moves `Repository invariants` ahead of `Commit the result` in `translate.yml` and makes the push conditional on it. An invalid tree now lands on a rescue branch instead of on master.

## Why

The check was the **last** step in the job, so it was a post-mortem, not a gate. [Run 33307609143](https://github.com/zeloras/through-metal-link/actions/runs/33307609143) translated thirteen dead anchors, committed them, pushed them to master, and only then went red — reporting on a tree that was already public. #29 fixed the bug that produced those anchors; this fixes the fact that nothing stopped them from shipping.

The step's own comment states the stakes: bot pushes carry `GITHUB_TOKEN` and by design trigger no CI, so this is the only gate master ever gets. Running it after the push means master effectively has none.

## How

The check runs before the commit step with `continue-on-error: true`, so its verdict reaches that step rather than ending the job. The commit is still made unconditionally — the model was paid for the work and discarding it means paying again, which is why the step is `always()` in the first place — but where it lands depends on the verdict:

| Invariants | Where the commit goes | Job |
|---|---|---|
| pass | the branch, exactly as before | green |
| fail | `sync-rescue/<run_id>`, master untouched | red, with the branch name in the error |

`translations/.sync-state.json` rides along with the commit either way, so a rescued run is never silently marked done: fix the invariants on that branch and merge it, or drop it and let the next sync redo the pairs.

The two "nothing to commit" exits now fail instead of reporting success when the check failed — a clean tree that violates the invariants means the branch was already broken before this run, and staying green would hide it until some unrelated change tripped over it.

## Verification

The step's shell was extracted and run against a throwaway `origin`, all four paths:

```
invalid tree + work   → commit made, pushed to sync-rescue/999888,
                        origin/master still at "init", exit 1
valid tree + work     → pushed to master, exit 0
nothing to sync, broken tree → exit 1 with the "broken independently of this run" error
nothing to sync, clean       → exit 0
```

Plus `bash -n` on the step and a YAML parse of the workflow.

## What this does not change

Step order aside, the staging logic, the pathspec file, the figure directories and the rebase-retry push loop are untouched.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — the DCO check is mandatory ([CONTRIBUTING.md](https://github.com/zeloras/through-metal-link/blob/master/CONTRIBUTING.md) §2)
- [x] Design decisions trace back to expired patents / papers from [docs/01-prior-art.md](https://github.com/zeloras/through-metal-link/blob/master/docs/01-prior-art.md) (§3) — n/a, CI only
- [x] Code comments, identifiers and commit messages are in English (§3)
- [ ] Experiments follow [experiments/TEMPLATE.md](https://github.com/zeloras/through-metal-link/blob/master/experiments/TEMPLATE.md) — n/a

## Languages

No documentation touched.