### PR TITLE
chore: P0 landing fixes for growth

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-software.md
+++ b/.github/ISSUE_TEMPLATE/bug-software.md
@@ -1,0 +1,20 @@
+---
+name: Software / simulator bug
+about: Bugs in sweep-map, simulator, CI, or tooling — not hardware bounty claims.
+title: "[bug] "
+labels: ["bug"]
+---
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+## What broke
+Command / path:
+
+## Expected vs actual
+
+## Environment
+OS / Python / Pi or host:
+
+## Repro steps
+1.
+2.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,18 @@
+---
+name: Docs / prior art / translation
+about: Documentation, prior-art notes, translations, ADR comments — no bench required.
+title: "[docs] "
+labels: ["documentation"]
+---
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+## What you want to change
+Path(s) and language (EN primary, or `translations/<lang>/…`):
+
+## Why
+Short rationale:
+
+## Checklist
+- [ ] I will edit **one** language only (CI syncs the rest) unless this is EN-canonical structure
+- [ ] Patent/prior-art claims cite sources; no invented lab data

--- a/.github/ISSUE_TEMPLATE/hardware-build.md
+++ b/.github/ISSUE_TEMPLATE/hardware-build.md
@@ -20,7 +20,7 @@ Which experiment protocol? (e.g. 001 sweep map / 002 watts / other)
 - [ ] Photos of the rig (required)
 - [ ] Video of the run (≥20s preferred; required for watts/LED)
 - [ ] CSV / logs under `data/` or `experiments/…`
-- [ ] Filled [experiments/TEMPLATE.md](../experiments/TEMPLATE.md)
+- [ ] Filled [experiments/TEMPLATE.md](https://github.com/zeloras/through-metal-link/blob/master/experiments/TEMPLATE.md)
 
 ## Notes
-Code-only or AI PRs with no measured data will be closed. Read [docs/02-safety.md](../docs/02-safety.md) before first power-up.
+Code-only or AI PRs with no measured data will be closed. Read [docs/02-safety.md](https://github.com/zeloras/through-metal-link/blob/master/docs/02-safety.md) before first power-up.

--- a/.github/ISSUE_TEMPLATE/hardware-build.md
+++ b/.github/ISSUE_TEMPLATE/hardware-build.md
@@ -1,0 +1,26 @@
+---
+name: Hardware build / experiment
+about: Measurements from a physical rig (steel + transducers). Not for code-only PRs.
+title: "[hardware] "
+labels: ["hardware"]
+---
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+## Goal
+Which experiment protocol? (e.g. 001 sweep map / 002 watts / other)
+
+## Bench
+- Transducers (type, source, batch):
+- Plate (material, thickness):
+- Contact method (grease+clamp / dry / epoxy):
+- Instruments (scope / ADC / PSU):
+
+## Data you will attach
+- [ ] Photos of the rig (required)
+- [ ] Video of the run (≥20s preferred; required for watts/LED)
+- [ ] CSV / logs under `data/` or `experiments/…`
+- [ ] Filled [experiments/TEMPLATE.md](../experiments/TEMPLATE.md)
+
+## Notes
+Code-only or AI PRs with no measured data will be closed. Read [docs/02-safety.md](../docs/02-safety.md) before first power-up.

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -30,11 +30,11 @@ Code files carry SPDX headers (Apache-2.0); the machine-readable coverage map is
 - **Third-party patents that already exist.** No license can do that. What works against them is the engineering discipline of docs/01-prior-art.md: build only from the expired layer (public domain), do not implement the live claims listed there (RPI, Drexel, and the Navy/ABB/Ultrapower families added in 2026-08 — note that they are not all US-only and not all expire around 2032), and trace every design decision back to a free source. That is no guarantee, but it is exactly the practice that makes a lawsuit futile.
 - A fork headed for commercial production does its own FTO (freedom to operate) analysis for its own jurisdiction and design — the repository makes no patent representations (disclaimers in all three licenses).
 
-## Defensive publication protocol (execute when the repo goes public)
+## Defensive publication protocol (keep executing as milestones publish)
 
 Every published result is dated prior art that blocks all later third-party applications for the same solution:
 
-1. Open the repository with its full git history (commits = timestamps).
+1. Keep the full public git history intact (commits = timestamps).
 2. Snapshot to **Zenodo** → DOI: an independent archive with a legally meaningful date, citable in papers.
 3. Pin it in **Software Heritage** (archive.softwareheritage.org — a perpetual mirror).
 4. Every completed experiment `experiments/NNN` — with a date, numbers, and plots: that is the publication of a specific technical solution.
@@ -44,4 +44,4 @@ Every published result is dated prior art that blocks all later third-party appl
 
 The rules live in [CONTRIBUTING.md](CONTRIBUTING.md): DCO sign-off, inbound=outbound, an explicit patent grant on every contribution regardless of directory, traceability of design decisions to free prior art.
 
-Until it opens, the repository stays private — publishing before the first reproducible results would weaken both the scientific and the patent position.
+The repository is already public. Continue the protocol above on each milestone (Zenodo snapshot, Software Heritage pin, experiment writeups) so dated prior art stays strong as results land.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # through-metal-link
 
 > English (primary) · [Русский](translations/ru/README.md) · [Deutsch](translations/de/README.md) · [Português](translations/pt/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [Italiano](translations/it/README.md) · [Polski](translations/pl/README.md) · [Türkçe](translations/tr/README.md) · [Українська](translations/uk/README.md) · [Tiếng Việt](translations/vi/README.md) · [中文](translations/zh/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [हिन्दी](translations/hi/README.md)
@@ -8,7 +6,12 @@ An open platform for ultrasonic power and data transfer through solid metal wall
 
 **Try it now (no hardware needed):** `python3 software/sweep-map/sweep_map.py --mock`
 
-**Status:** stage 0 — preparation · 💰 **[$250 bounty for the first independent build](https://github.com/zeloras/through-metal-link/issues)** · shopping list: [QUICKSTART.md](QUICKSTART.md)
+**Paths in:**
+- **A — dry-run:** mock sweep + [simulator](software/simulator/channel_sim.py) (no bench)
+- **B — build stage 1:** [QUICKSTART.md](QUICKSTART.md) → [experiments/001](experiments/001-sweep-map-3mm-steel/README.md)
+- **C — contribute without hardware:** prior-art / docs / translations / ADR comments ([CONTRIBUTING.md](CONTRIBUTING.md))
+
+**Status:** stage 0 — preparation · **no hardware validation yet** (simulator only; bounty for the first build) · 💰 **[$250 bounty](https://github.com/zeloras/through-metal-link/issues/5)** · shopping list: [QUICKSTART.md](QUICKSTART.md)
 
 [![CI](https://github.com/zeloras/through-metal-link/actions/workflows/ci.yml/badge.svg)](https://github.com/zeloras/through-metal-link/actions/workflows/ci.yml) [![REUSE](https://github.com/zeloras/through-metal-link/actions/workflows/reuse.yml/badge.svg)](https://github.com/zeloras/through-metal-link/actions/workflows/reuse.yml) [![DCO](https://img.shields.io/badge/DCO-signed--off--by-blue)](CONTRIBUTING.md) [![License](https://img.shields.io/badge/license-Apache--2.0%20%7C%20CERN--OHL--W%20v2%20%7C%20CC--BY--4.0-blue)](LICENSES.md)
 
@@ -28,7 +31,7 @@ Radio waves don't pass through metal (Faraday cage), and a cable penetration mea
 | 2. Watts | power into the load at resonance | ≥0.5 W through 3 mm of steel, protocol in [experiments/002](experiments/002-watts-3mm-steel/README.md) | [sim4](docs/img/sim4-power-budget.png) |
 | 3. Data | FSK/OOK over the same pair | ≥1 kbit/s error-free | [sim5](docs/img/sim5-ook-datarate.png) |
 | 4. Node | ESP32 + sensor in a welded-shut box, powered and telemetered by sound alone | ≥1 h of autonomous operation | [sim4](docs/img/sim4-power-budget.png) |
-| 5. Publication | repo goes public, article/how-to | reproduction by a third party | — |
+| 5. Publication | first independent replication + article/how-to + Zenodo snapshot | third-party reproduction documented | — |
 
 ## Repository map
 


### PR DESCRIPTION
## Summary

P0 landing fixes aimed at clearer growth funnel and less bounty spam.

### In this PR
- **Status honesty** — stage 0 clearly says *no hardware validation yet* (simulator only; bounty for first build)
- **Roadmap stage 5** — publication stage no longer implies making the repo public (it already is); success = independent replication + writeup + Zenodo
- **Three paths in** — dry-run (A), build stage 1 (B), docs/prior-art/translations without hardware (C)
- **LICENSES.md public-status fix** — remove stale private-repo language; state the repo is already public and keep the defensive-publication protocol
- **Issue templates** — software bug, docs/prior-art, and hardware-build templates to cut bounty spam and route contributors

### Already done outside this PR
- Issue [#5](https://github.com/zeloras/through-metal-link/issues/5) labels set to `bounty` + `hardware` (removed `good first issue`)

### Still manual
- Pin **Build Q&A** Discussion
- GitHub license UI still shows **Other** (expected for multi-license Apache-2.0 | CERN-OHL-W v2 | CC-BY-4.0)